### PR TITLE
Fix Comment Deletion Bug

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,6 @@ inputs:
   comment-footer:
     description: "Footer text for the Github comment"
     required: false
-    default: ""
   include-hidden-files:
     description: "Includes files and folders starting with '.' in file pattern matching"
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -14987,19 +14987,21 @@ function run() {
             owner: owner,
             repo: repo,
             issue_number: number
-        })).data.find(comment => comment.body.includes(footer));
+        })).data.find(comment => comment.body.includes(header) && comment.user.login === "github-actions[bot]");
         if (applicableChecklistPaths.length > 0) {
             const body = [
                 `${header}\n\n`,
                 formatItemsForPath(applicableChecklistPaths),
-                `\n${footer}`,
-            ].join("");
+            ];
+            if (footer) {
+                body.push(`\n${footer}`);
+            }
             if (existingComment) {
                 yield client.rest.issues.updateComment({
                     owner: owner,
                     repo: repo,
                     comment_id: existingComment.id,
-                    body
+                    body: body.join("")
                 });
             }
             else {
@@ -15007,7 +15009,7 @@ function run() {
                     owner: owner,
                     repo: repo,
                     issue_number: number,
-                    body
+                    body: body.join("")
                 });
             }
         }

--- a/index.ts
+++ b/index.ts
@@ -88,7 +88,7 @@ async function run() {
       repo: repo,
       issue_number: number
     })
-  ).data.find(comment => comment.body.includes(footer));
+  ).data.find(comment => comment.body.includes(header) && comment.user.login === "github-actions[bot]");
 
   if (applicableChecklistPaths.length > 0) {
     const body = [

--- a/index.ts
+++ b/index.ts
@@ -94,22 +94,25 @@ async function run() {
     const body = [
       `${header}\n\n`,
       formatItemsForPath(applicableChecklistPaths),
-      `\n${footer}`,
-    ].join("");
+    ]
+
+    if (footer) {
+      body.push(`\n${footer}`)
+    }
 
     if (existingComment) {
       await client.rest.issues.updateComment({
         owner: owner,
         repo: repo,
         comment_id: existingComment.id,
-        body
+        body: body.join("")
       });
     } else {
       await client.rest.issues.createComment({
         owner: owner,
         repo: repo,
         issue_number: number,
-        body
+        body: body.join("")
       });
     }
   } else {


### PR DESCRIPTION
## Description
In #3 we removed the default string for the footer and set footer to not be required.

This introduced a bug because the default for the footer is an empty string. As a result, when we looked for the first instance of a comment that CONTAINED an empty string, it would always return the first comment in the list, thus it would always delete any comment.

We will now search for a comment that includes the header, since that is required, and was created by the GitHub action bot. This is to ensure comments made by other people are not deleted.

cr_req 2