### PR TITLE
Update to use node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: true
     default: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "check-square"


### PR DESCRIPTION
## Summary
Node 12 is getting deprecated on gh action runners, so let's update it to node 16. 

Steps used:
1. Updated the `action.yml` to use `node16`
2. `npm install`; `npm run build-dist`. Confirmed that nothing was changed in the dist folder. 

## QA Notes

Create a test pull request based from this branch and modify the paths specified in https://github.com/iFixit/contextual-qa-checklist-action/blob/master/CHECKLIST.yml.

Then makes sure it comments the checklist comment. 