### PR TITLE
QA Checklist: Upgrade node

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: true
     default: true
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "check-square"


### PR DESCRIPTION
This updates the node version this action uses from Node 16 to Node 20.

Node 16 is EOL and deprecated.

Connects: https://github.com/iFixit/ifixit/issues/51902